### PR TITLE
fix: Add NoneType as a local member to the _common module

### DIFF
--- a/aenum/_common.py
+++ b/aenum/_common.py
@@ -76,7 +76,7 @@ except NameError:
 baseint = baseinteger
 
 try:
-    NoneType
+    NoneType = NoneType
 except NameError:
     NoneType = type(None)
 


### PR DESCRIPTION
#32  Provides a consistent way to handle the NoneType. Now even when using pypy it creates a local attribute in the _common module, this is imported in the __init__.py, where if we don't have attribute but it is declared in the slots then it freaks out.

try:
    NoneType
except NameError:
    NoneType = type(None)

>>>

try:
    NoneType = NoneType
except NameError:
    NoneType = type(None)