### PR TITLE
Remove python 2 support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ include aenum/_common.py
 include aenum/_constant.py
 include aenum/_enum.py
 include aenum/_tuple.py
-include aenum/_py2.py
 include aenum/_py3.py
 include aenum/test.py
 include aenum/test_v3.py

--- a/aenum/__init__.py
+++ b/aenum/__init__.py
@@ -12,7 +12,7 @@ from ._enum import *
 
 __all__ = [
         'NamedConstant', 'Constant', 'constant', 'skip', 'nonmember', 'member', 'no_arg',
-        'Member', 'NonMember', 'bin', 
+        'Member', 'NonMember', 'bin',
         'Enum', 'IntEnum', 'AutoNumberEnum', 'OrderedEnum', 'UniqueEnum',
         'StrEnum', 'UpperStrEnum', 'LowerStrEnum', 'ReprEnum',
         'Flag', 'IntFlag', 'enum_property',
@@ -28,13 +28,9 @@ if sqlite3 is None:
     __all__.remove('SqliteEnum')
 
 
-if PY2:
-    from . import _py2
-    __all__.extend(_py2.__all__)
-else:
-    from . import _py3
-    __all__.extend(_py3.__all__)
-    __all__.append('AutoEnum')
+from . import _py3
+__all__.extend(_py3.__all__)
+__all__.append('AutoEnum')
 
 
 

--- a/aenum/_common.py
+++ b/aenum/_common.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 __all__ = [
-        'pyver', 'PY2', 'PY2_6', 'PY3', 'PY3_3', 'PY3_4', 'PY3_5', 'PY3_6', 'PY3_7', 'PY3_11',
+        'pyver', 'PY3', 'PY3_3', 'PY3_4', 'PY3_5', 'PY3_6', 'PY3_7', 'PY3_11',
         '_or_', '_and_', '_xor_', '_inv_', '_abs_', '_add_', '_floordiv_', '_lshift_',
         '_rshift_', '_mod_', '_mul_', '_neg_', '_pos_', '_pow_', '_truediv_', '_sub_',
         'unicode', 'basestring', 'baseinteger', 'long', 'NoneType', '_Addendum',
@@ -15,9 +15,7 @@ __all__ = [
 # imports
 import sys as _sys
 pyver = _sys.version_info[:2]
-PY2 = pyver < (3, )
 PY3 = pyver >= (3, )
-PY2_6 = (2, 6)
 PY3_3 = (3, 3)
 PY3_4 = (3, 4)
 PY3_5 = (3, 5)
@@ -33,14 +31,9 @@ from operator import lshift as _lshift_, rshift as _rshift_, mod as _mod_
 from operator import mul as _mul_, neg as _neg_, pos as _pos_, pow as _pow_
 from operator import truediv as _truediv_, sub as _sub_
 
-if PY2:
-    from . import _py2
-    from ._py2 import *
-    __all__.extend(_py2.__all__)
-if PY3:
-    from . import _py3
-    from ._py3 import *
-    __all__.extend(_py3.__all__)
+from . import _py3
+from ._py3 import *
+__all__.extend(_py3.__all__)
 
 bltin_property = property
 
@@ -199,9 +192,6 @@ class constant(object):
         return _neg_(self.value)
     def __pos__(self):
         return _pos_(self.value)
-    if PY2:
-        def __div__(self, other):
-            return _div_(self.value, _value(other))
     def __rdiv__(self, other):
         return _div_(_value(other), (self.value))
     def __floordiv__(self, other):

--- a/aenum/_enum.py
+++ b/aenum/_enum.py
@@ -17,7 +17,7 @@ __all__ = [
         'add_stdlib_integration', 'remove_stdlib_integration',
         'export', 'cls2module', '_reduce_ex_by_name', 'show_flag_values',
         ]
-        
+
 
 _bltin_bin = bin
 
@@ -613,12 +613,6 @@ class auto(enum):
         new_auto._operations.append((_pos_, (self, )))
         return new_auto
 
-    if PY2:
-        def __div__(self, other):
-            new_auto = self.__class__()
-            new_auto._operations = self._operations[:]
-            new_auto._operations.append((_div_, (self, other)))
-            return new_auto
 
     def __rdiv__(self, other):
         new_auto = self.__class__()
@@ -1732,24 +1726,6 @@ class EnumType(type):
         #
         # method resolution and int's are not playing nice
         # Python's less than 2.6 use __cmp__
-        if pyver < PY2_6:
-            #
-            if issubclass(enum_class, int):
-                setattr(enum_class, '__cmp__', getattr(int, '__cmp__'))
-            #
-        elif PY2:
-            #
-            if issubclass(enum_class, int):
-                for method in (
-                        '__le__',
-                        '__lt__',
-                        '__gt__',
-                        '__ge__',
-                        '__eq__',
-                        '__ne__',
-                        '__hash__',
-                        ):
-                    setattr(enum_class, method, getattr(int, method))
         #
         # replace any other __new__ with our own (as long as Enum is not None,
         # anyway) -- again, this is to support pickle
@@ -2020,13 +1996,6 @@ class EnumType(type):
         * An iterable of (member name, value) pairs.
         * A mapping of member name -> value.
         """
-        if PY2:
-            # if class_name is unicode, attempt a conversion to ASCII
-            if isinstance(class_name, unicode):
-                try:
-                    class_name = class_name.encode('ascii')
-                except UnicodeEncodeError:
-                    raise TypeError('%r is not representable in ASCII' % (class_name, ))
         metacls = cls.__class__
         if type is None:
             bases = (cls, )
@@ -2578,8 +2547,6 @@ class AutoNumberEnum(Enum):
     Automatically assign increasing values to members.
 
     Py3: numbers match creation order
-    Py2: numbers are assigned alphabetically by member name
-         (unless `_order_` is specified)
     """
 
     def __new__(cls, *args, **kwds):
@@ -3173,14 +3140,9 @@ def __str__(self):
     else:
         return '%s.%s' % (cls.__name__, self._name_)
 
-if PY2:
-    @flag_dict
-    def __nonzero__(self):
-        return bool(self._value_)
-else:
-    @flag_dict
-    def __bool__(self):
-        return bool(self._value_)
+@flag_dict
+def __bool__(self):
+    return bool(self._value_)
 
 @flag_dict
 def _get_value(self, flag):

--- a/aenum/_py2.py
+++ b/aenum/_py2.py
@@ -1,7 +1,0 @@
-from operator import div as _div_
-from inspect import getargspec
-
-def raise_with_traceback(exc, tb):
-    raise exc, None, tb
-
-__all__ = ['_div_', 'getargspec', 'raise_with_traceback']

--- a/aenum/_tuple.py
+++ b/aenum/_tuple.py
@@ -300,13 +300,6 @@ class NamedTupleMeta(type):
                 raise TypeError('too few arguments to NamedTuple: %s, %s' % (original_args, original_kwds))
             if args or kwds:
                 raise TypeError('too many arguments to NamedTuple: %s, %s' % (original_args, original_kwds))
-            if PY2:
-                # if class_name is unicode, attempt a conversion to ASCII
-                if isinstance(class_name, unicode):
-                    try:
-                        class_name = class_name.encode('ascii')
-                    except UnicodeEncodeError:
-                        raise TypeError('%r is not representable in ASCII' % (class_name, ))
             # quick exit if names is a NamedTuple
             if isinstance(names, NamedTupleMeta):
                 names.__name__ = class_name

--- a/setup.py
+++ b/setup.py
@@ -109,25 +109,10 @@ data = dict(
             ],
     )
 
-py2_only = ('aenum/_py2.py', )
 py3_only = ('aenum/test_v3.py', 'aenum/test_v37.py', 'aenum/_py3.py')
 make = [
         'rst2pdf aenum/doc/aenum.rst --output=aenum/doc/aenum.pdf',
         ]
 
 if __name__ == '__main__':
-    if 'install' in sys.argv:
-        import os
-        if sys.version_info[0] != 2:
-            for file in py2_only:
-                try:
-                    os.unlink(file)
-                except OSError:
-                    pass
-        if sys.version_info[0] != 3:
-            for file in py3_only:
-                try:
-                    os.unlink(file)
-                except OSError:
-                    pass
     setup(**data)


### PR DESCRIPTION
the existence of python code means we cannot compile aenum to bytecode with `compileall`, without resorting to deleting `_py2.py`. This PR attempts to remove python 2 support instead. closes #51 